### PR TITLE
PUT /resource/1 should append data if "resource" is a list

### DIFF
--- a/json_server/handlers.py
+++ b/json_server/handlers.py
@@ -86,6 +86,8 @@ class DataWrapper:
                 if str(item.get(FIELD_ID)) == last_key:
                     break
             else:
+                if value is not None:
+                    parent.append({**value, FIELD_ID: last_key})
                 return
             if value is None:
                 del parent[index]


### PR DESCRIPTION
Current behavior:

```
$ curl localhost:3000
{"foo": []}
$ curl -XPUT -Hcontent-type:application/json -d'{"test":123}' localhost:3000/foo/1
{"test": 123}
$ curl localhost:3000
{"foo": []}
```
It responds to the PUT request with 200 OK, but nothing is actually added.

It should instead result in db.json holding `{"foo": [{"id": "1", "test": 123}]}`