### PR TITLE
ISSUE #7 only convert "simple" ints

### DIFF
--- a/json_server/handlers.py
+++ b/json_server/handlers.py
@@ -93,6 +93,8 @@ class DataWrapper:
                     item_id = int(last_key)
                 except ValueError:
                     item_id = last_key
+                if str(item_id) != last_key:
+                    item_id = last_key
                 value = {
                     **value,
                     FIELD_ID: item_id,


### PR DESCRIPTION
If conversion to int and back to str ends up different, use original string
as id instead.

This fixes #7